### PR TITLE
fix out_bind

### DIFF
--- a/shadowsocks/server.py
+++ b/shadowsocks/server.py
@@ -82,8 +82,8 @@ def main():
         protocol_param = config.get("protocol_param", '')
         obfs = config.get("obfs", 'plain')
         obfs_param = config.get("obfs_param", '')
-        bind = config.get("out_bind", '')
-        bindv6 = config.get("out_bindv6", '')
+        bind = common.to_str(config.get("out_bind", ''))
+        bindv6 = common.to_str(config.get("out_bindv6", ''))
         if type(password_obfs) == list:
             password = password_obfs[0]
             obfs = common.to_str(password_obfs[1])


### PR DESCRIPTION
2019-05-18 17:33:19 ERROR    shell.py:50 'str' does not support the buffer interface
Traceback (most recent call last):
  File "/var/sm-server-base/services/ssr/shadowsocksr/shadowsocks/../shadowsocks/tcprelay.py", line 774, in _handle_dns_resolved
    remote_port)
  File "/var/sm-server-base/services/ssr/shadowsocksr/shadowsocks/../shadowsocks/tcprelay.py", line 744, in _create_remote_socket
    self._socket_bind_addr(remote_sock, af)
  File "/var/sm-server-base/services/ssr/shadowsocksr/shadowsocks/../shadowsocks/tcprelay.py", line 687, in _socket_bind_addr
    bind_addr = bind_addr.replace("::ffff:", "")
TypeError: 'str' does not support the buffer interface