### PR TITLE
Travis CI: Drop EOL versions of Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.3
-  - 3.4
+  - 3.6
+  - 3.7
 cache:
   directories:
     - dante-1.4.0


### PR DESCRIPTION
https://devguide.python.org/devcycle/#end-of-life-branches
https://devguide.python.org/#branchstatus