### PR TITLE
docs: fix simple typo, instatiates -> instantiates

### DIFF
--- a/shadowsocks/eventloop.py
+++ b/shadowsocks/eventloop.py
@@ -231,7 +231,7 @@ def errno_from_exception(e):
     """Provides the errno from an Exception object.
 
     There are cases that the errno attribute was not set so we pull
-    the errno out of the args but if someone instatiates an Exception
+    the errno out of the args but if someone instantiates an Exception
     without any args you will get a tuple error. So this function
     abstracts all that behavior to give you a safe way to get the
     errno.


### PR DESCRIPTION
There is a small typo in shadowsocks/eventloop.py.

Should read `instantiates` rather than `instatiates`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md